### PR TITLE
Rename the plugin in setup.py so standard pylint plugin can be overriden

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     use_scm_version={'write_to': '_version.py'},
     url='%doc% link',
     py_modules=['pytest_pylint_xdist_vcs', 'svn'],
-    entry_points={'pytest11': ['pylint = pytest_pylint_xdist_vcs']},
+    entry_points={'pytest11': ['pylint-xdist = pytest_pylint_xdist_vcs']},
     install_requires=INSTALL_REQS,
     setup_requires=['pytest-runner', 'setuptools_scm', 'setuptools>=24.2.0', 'pip>=9.0.0'],
     tests_require=['coverage'],


### PR DESCRIPTION
Thank you for this very useful plugin that fixed the exact issue I was having at the time I needed it!

This commit solves a problem that I had, but it may not be a general problem for others, and it has other knock-on effects, so no problem if it’s not something you want to merge in.

In my scenario, we have a few different services which all run their tests in separate docker containers, but share the test requirements that they copy in (which include purest-pylint).  We just started to run the test of just a couple of them in parallel with pytest-xdist and pytest-pylint-xdist-vcs, and we’ve found that occasionally, and somewhat randomly, the pytest-pylint-xdist-vcs plugin wasn’t picked up by pytest, causing all the linting to error.  Turns out the issue was that we had both pytest-pylint-xdist-vcs and pytest-pylint installed, and they have the same plugin name. If pytest loaded pytest-pylint first, everything was fine, but if it loaded pytest-pylint-xdist-vcs first, it would fail.  For reasons, we don’t want to have to install and then uninstall pytest-pylint on the services running parallel tests.

My workaround is to add `addopts = -p no:pylint` to my pytest.ini, and to rename the plugin in pytest-pylint-xdist-vcs to ensure that it doesn’t get ignored as well.

The knock-on issue is that if you have both installed and you *don’t* explicitly ignore pytest-pylint, pytest will now complain that the —pylint option is defined twice.